### PR TITLE
Fix deepEqual and notDeepEqual for objects/arrays with falsey values

### DIFF
--- a/src/gas-tap-lib.js
+++ b/src/gas-tap-lib.js
@@ -227,7 +227,7 @@ var GasTap = (function () {
         if (Object.keys(rv1).length != Object.keys(rv2).length) return false
       
         for (var k in rv1) {
-          if (!rv2[k] 
+          if (!(k in rv2)
               || ((typeof rv1[k]) != (typeof rv2[k]))
           ) return false
         
@@ -257,7 +257,7 @@ var GasTap = (function () {
         if (Object.keys(rv1).length != Object.keys(rv2).length) return true
       
         for (var k in rv1) {
-          if (!rv2[k] 
+          if (!(k in rv2)
               || ((typeof rv1[k]) != (typeof rv2[k]))
           ) return true
         

--- a/src/gast-tests.js
+++ b/src/gast-tests.js
@@ -49,6 +49,9 @@ function gastTestRunner() {
     
     t.deepEqual(a, a2, 'a deepEqual a2')
     t.notDeepEqual(a, b, 'a notDeepEqual b')
+    
+    t.deepEqual([0], [0], '[0] deepEqual [0]')
+    t.notDeepEqual([0], [0], 'this should fail: [0] notDeepEqual [0]')
   })
   
   test('TAP exception', function (t) {


### PR DESCRIPTION
Thanks for this library! I found it from your answer on SO [here](http://stackoverflow.com/a/34027266/4492726), and it's great as a much lighter test framework than the alternatives.

I found a bug when I was comparing numeric arrays that contained zero values. This should fix the problem by checking for the existence of the key in the second object, rather than checking for a falsey value on that key. The two added tests behave as expected (pass/fail) after this change, while they are both incorrect on the current master (fail/pass).
