### PR TITLE
isNaN feature is added

### DIFF
--- a/src/gas-tap-lib.js
+++ b/src/gas-tap-lib.js
@@ -30,90 +30,93 @@ var GasTap = (function () {
   var EXCEPTION_SKIP = 'GasTapSkip'
   var EXCEPTION_PASS = 'GasTapPass'
   var EXCEPTION_FAIL = 'GasTapFail'
-  
+
   var GasTap = function (options) {
-    
+
     var totalSucc = 0
     var totalFail = 0
     var totalSkip = 0
-    
-    var t = {    
+
+    var t = {
       counter: 0
       , succCounter: 0
       , failCounter: 0
       , skipCounter: 0
       , description: 'unknown description'
-      
+
       , ok: ok
       , notOk: notOk
-      
+
       , equal: equal
       , notEqual: notEqual
-      
+
       , deepEqual: deepEqual
       , notDeepEqual: notDeepEqual
-      
+
+      , isNaN: isNaN
+      , notIsNaN: notIsNaN
+
       , throws: throws
       , notThrow: notThrow
-      
+
       , skip: skip
       , pass: pass
       , fail: fail
-      
-      , reset: function () { 
+
+      , reset: function () {
         this.succCounter = this.failCounter = this.skipCounter = 0
         this.description = 'unknown'
       }
 
     }
-    
+
     // default output to gas logger.log
     var loggerFunc = function (msg) { Logger.log(msg) }
-    
+
     if (options && options.logger) {
       var loggerFunc = options.logger;
     }
-    
+
     if (typeof loggerFunc != 'function') throw Error('options.logger must be a function to accept output parameter');
-    
+
     print('TAP version GasTap v' + VERSION + '(BUGGY)')
-  
+
     /***************************************************************
     *
     * Instance methods export 
     *
     ****************************************************************/
     test.end = finish
-    
+
     // The alias to test.end
     test.finish = test.end
-  
-    
+
+
     return test
-  
+
 
     /***************************************************************
     *
     * Instance methods implementions
     *
     ****************************************************************/
-    function test(description, run) {  
-    
+    function test(description, run) {
+
       t.reset()
 
       t.description = description
-      
+
       try {
-      
+
         run(t)
-      
-      } catch ( e /* if e instanceof String */) {
+
+      } catch (e /* if e instanceof String */) {
         //      Logger.log('caught exception: ' + e)
-        
+
         SKIP_RE = new RegExp(EXCEPTION_SKIP)
         PASS_RE = new RegExp(EXCEPTION_PASS)
         FAIL_RE = new RegExp(EXCEPTION_FAIL)
-        
+
         switch (true) {
           case SKIP_RE.test(e):
           case PASS_RE.test(e):
@@ -122,23 +125,23 @@ var GasTap = (function () {
           default:
             if (e instanceof Error) Logger.log('Stack:\n' + e.stack)
             throw e
-        }      
-      } finally { 
+        }
+      } finally {
         totalSucc += t.succCounter
         totalFail += t.failCounter
         totalSkip += t.skipCounter
         //      print('succCounter: %s, failCounter: %s, skipCounter: %s', t.succCounter, t.failCounter, t.skipCounter)
       }
     }
-    
+
     function print() {
       var args = Array.prototype.slice.call(arguments)
-      
+
       var message = Utilities.formatString.apply(null, args)
       loggerFunc(message)
     }
-    
-    
+
+
     function tapOutput(ok, msg) {
       print(
         (ok ? 'ok' : 'not ok')
@@ -148,33 +151,33 @@ var GasTap = (function () {
       )
     }
 
-    
+
     /**
      * Prints a total line to log output. For an example "3 tests, 0 failures"
      * 
      * @returns void
      */
-    function finish () { 
+    function finish() {
       var totalNum = totalSucc + totalFail + totalSkip
-      
+
       //    print("%s, %s, %s, %s", totalSucc, totalFail, totalSkip, t.counter)
-      
+
       if (totalNum != (t.counter)) {
         throw Error('test counting error!')
       }
-      
+
       var msg = Utilities.formatString('%s..%s'
-                                       , Math.floor(totalNum)>0 ? 1 : 0
-                                       , Math.floor(totalNum))
+        , Math.floor(totalNum) > 0 ? 1 : 0
+        , Math.floor(totalNum))
       print(msg)
-      
+
       msg = Utilities.formatString('%s tests, %s failures', Math.floor(totalNum), Math.floor(totalFail))
-      
-      if (totalSkip>0) {
+
+      if (totalSkip > 0) {
         msg += ', ' + Math.floor(totalSkip) + ' skipped'
       }
-      
-      print(msg) 
+
+      print(msg)
     }
 
     /***************************************************************
@@ -182,7 +185,7 @@ var GasTap = (function () {
     * T 's functions
     *
     ****************************************************************/
-    
+
     function ok(value, msg) {
       if (value) {
         this.succCounter++;
@@ -192,7 +195,7 @@ var GasTap = (function () {
         tapOutput(false, msg)
       }
     }
-    
+
     function notOk(value, msg) {
       if (!value) {
         this.succCounter++;
@@ -202,7 +205,7 @@ var GasTap = (function () {
         tapOutput(false, msg)
       }
     }
-    
+
     function equal(v1, v2, msg) {
       if (v1 == v2) {
         this.succCounter++;
@@ -213,7 +216,7 @@ var GasTap = (function () {
         tapOutput(false, error + ' - ' + msg)
       }
     }
-    
+
     function notEqual(v1, v2, msg) {
       if (v1 != v2) {
         this.succCounter++;
@@ -226,25 +229,25 @@ var GasTap = (function () {
     }
 
     function deepEqual(v1, v2, msg) {
-      
+
       var isDeepEqual = recursionDeepEqual(v1, v2)
-      
+
       function recursionDeepEqual(rv1, rv2) {
         if (!(rv1 instanceof Object) || !(rv2 instanceof Object)) return rv1 == rv2
-        
+
         if (Object.keys(rv1).length != Object.keys(rv2).length) return false
-      
+
         for (var k in rv1) {
           if (!(k in rv2)
-              || ((typeof rv1[k]) != (typeof rv2[k]))
+            || ((typeof rv1[k]) != (typeof rv2[k]))
           ) return false
-        
+
           if (!recursionDeepEqual(rv1[k], rv2[k])) return false
         }
-        
+
         return true
-      }        
-        
+      }
+
       if (isDeepEqual) {
         this.succCounter++;
         tapOutput(true, msg)
@@ -254,27 +257,27 @@ var GasTap = (function () {
         tapOutput(false, error + ' - ' + msg)
       }
     }
-    
+
     function notDeepEqual(v1, v2, msg) {
-      
+
       var isNotDeepEqual = recursionNotDeepEqual(v1, v2)
-      
+
       function recursionNotDeepEqual(rv1, rv2) {
         if (!(rv1 instanceof Object) || !(rv2 instanceof Object)) return rv1 != rv2
-        
+
         if (Object.keys(rv1).length != Object.keys(rv2).length) return true
-      
+
         for (var k in rv1) {
           if (!(k in rv2)
-              || ((typeof rv1[k]) != (typeof rv2[k]))
+            || ((typeof rv1[k]) != (typeof rv2[k]))
           ) return true
-        
+
           if (recursionNotDeepEqual(rv1[k], rv2[k])) return true
         }
-        
+
         return false
       }
-      
+
       if (isNotDeepEqual) {
         this.succCounter++;
         tapOutput(true, msg)
@@ -284,11 +287,33 @@ var GasTap = (function () {
         tapOutput(false, error + ' - ' + msg)
       }
     }
-    
+
+    function isNaN(v1, msg) {
+      if (v1 !== v1) {
+        this.succCounter++;
+        tapOutput(true, msg)
+      } else {
+        this.failCounter++;
+        var error = Utilities.formatString('%s not is NaN', v1);
+        tapOutput(false, error + ' - ' + msg);
+      }
+    }
+
+    function notIsNaN(v1, msg) {
+      if (!(v1 !== v1)) {
+        this.succCounter++;
+        tapOutput(true, msg)
+      } else {
+        this.failCounter++;
+        var error = Utilities.formatString('%s is NaN', v1);
+        tapOutput(false, error + ' - ' + msg);
+      }
+    }
+
     function throws(fn, msg) {
       try {
         fn()
-        
+
         this.failCounter++;
         tapOutput(false, 'exception wanted - ' + msg)
       } catch (e) {
@@ -296,11 +321,11 @@ var GasTap = (function () {
         tapOutput(true, msg)
       }
     }
-    
+
     function notThrow(fn, msg) {
       try {
         fn()
-        
+
         this.succCounter++;
         tapOutput(true, msg)
       } catch (e) {
@@ -308,19 +333,19 @@ var GasTap = (function () {
         tapOutput(false, 'unexpected exception:' + e.message + ' - ' + msg)
       }
     }
-    
+
     function skip(msg) {
       this.skipCounter++;
       tapOutput(true, msg + ' # SKIP')
       throw EXCEPTION_SKIP
     }
-    
+
     function pass(msg) {
       this.succCounter++;
       tapOutput(true, msg + ' # PASS')
       throw EXCEPTION_PASS
     }
-    
+
     function fail(msg) {
       this.failCounter++;
       tapOutput(false, msg + ' # FAIL')
@@ -328,8 +353,8 @@ var GasTap = (function () {
     }
   }
 
-  
+
   return GasTap
-  
-  
+
+
 }())

--- a/src/gas-tap-lib.js
+++ b/src/gas-tap-lib.js
@@ -30,93 +30,93 @@ var GasTap = (function () {
   var EXCEPTION_SKIP = 'GasTapSkip'
   var EXCEPTION_PASS = 'GasTapPass'
   var EXCEPTION_FAIL = 'GasTapFail'
-
+  
   var GasTap = function (options) {
-
+    
     var totalSucc = 0
     var totalFail = 0
     var totalSkip = 0
-
-    var t = {
+    
+    var t = {    
       counter: 0
       , succCounter: 0
       , failCounter: 0
       , skipCounter: 0
       , description: 'unknown description'
-
+      
       , ok: ok
       , notOk: notOk
-
+      
       , equal: equal
       , notEqual: notEqual
-
+      
       , deepEqual: deepEqual
       , notDeepEqual: notDeepEqual
-
-      , isNaN: isNaN
-      , notIsNaN: notIsNaN
-
+      
       , throws: throws
       , notThrow: notThrow
 
+      , isNaN: isNaN
+      , notIsNaN: notIsNaN
+      
       , skip: skip
       , pass: pass
       , fail: fail
-
-      , reset: function () {
+      
+      , reset: function () { 
         this.succCounter = this.failCounter = this.skipCounter = 0
         this.description = 'unknown'
       }
 
     }
-
+    
     // default output to gas logger.log
     var loggerFunc = function (msg) { Logger.log(msg) }
-
+    
     if (options && options.logger) {
       var loggerFunc = options.logger;
     }
-
+    
     if (typeof loggerFunc != 'function') throw Error('options.logger must be a function to accept output parameter');
-
+    
     print('TAP version GasTap v' + VERSION + '(BUGGY)')
-
+  
     /***************************************************************
     *
     * Instance methods export 
     *
     ****************************************************************/
     test.end = finish
-
+    
     // The alias to test.end
     test.finish = test.end
-
-
+  
+    
     return test
-
+  
 
     /***************************************************************
     *
     * Instance methods implementions
     *
     ****************************************************************/
-    function test(description, run) {
-
+    function test(description, run) {  
+    
       t.reset()
 
       t.description = description
-
+      
       try {
-
+      
         run(t)
-
-      } catch (e /* if e instanceof String */) {
+      
+      } catch ( e /* if e instanceof String */) {
         //      Logger.log('caught exception: ' + e)
-
+        
         SKIP_RE = new RegExp(EXCEPTION_SKIP)
         PASS_RE = new RegExp(EXCEPTION_PASS)
         FAIL_RE = new RegExp(EXCEPTION_FAIL)
-
+        
         switch (true) {
           case SKIP_RE.test(e):
           case PASS_RE.test(e):
@@ -125,23 +125,23 @@ var GasTap = (function () {
           default:
             if (e instanceof Error) Logger.log('Stack:\n' + e.stack)
             throw e
-        }
-      } finally {
+        }      
+      } finally { 
         totalSucc += t.succCounter
         totalFail += t.failCounter
         totalSkip += t.skipCounter
         //      print('succCounter: %s, failCounter: %s, skipCounter: %s', t.succCounter, t.failCounter, t.skipCounter)
       }
     }
-
+    
     function print() {
       var args = Array.prototype.slice.call(arguments)
-
+      
       var message = Utilities.formatString.apply(null, args)
       loggerFunc(message)
     }
-
-
+    
+    
     function tapOutput(ok, msg) {
       print(
         (ok ? 'ok' : 'not ok')
@@ -151,33 +151,33 @@ var GasTap = (function () {
       )
     }
 
-
+    
     /**
      * Prints a total line to log output. For an example "3 tests, 0 failures"
      * 
      * @returns void
      */
-    function finish() {
+    function finish () { 
       var totalNum = totalSucc + totalFail + totalSkip
-
+      
       //    print("%s, %s, %s, %s", totalSucc, totalFail, totalSkip, t.counter)
-
+      
       if (totalNum != (t.counter)) {
         throw Error('test counting error!')
       }
-
+      
       var msg = Utilities.formatString('%s..%s'
-        , Math.floor(totalNum) > 0 ? 1 : 0
-        , Math.floor(totalNum))
+                                       , Math.floor(totalNum)>0 ? 1 : 0
+                                       , Math.floor(totalNum))
       print(msg)
-
+      
       msg = Utilities.formatString('%s tests, %s failures', Math.floor(totalNum), Math.floor(totalFail))
-
-      if (totalSkip > 0) {
+      
+      if (totalSkip>0) {
         msg += ', ' + Math.floor(totalSkip) + ' skipped'
       }
-
-      print(msg)
+      
+      print(msg) 
     }
 
     /***************************************************************
@@ -185,7 +185,7 @@ var GasTap = (function () {
     * T 's functions
     *
     ****************************************************************/
-
+    
     function ok(value, msg) {
       if (value) {
         this.succCounter++;
@@ -195,7 +195,7 @@ var GasTap = (function () {
         tapOutput(false, msg)
       }
     }
-
+    
     function notOk(value, msg) {
       if (!value) {
         this.succCounter++;
@@ -205,7 +205,7 @@ var GasTap = (function () {
         tapOutput(false, msg)
       }
     }
-
+    
     function equal(v1, v2, msg) {
       if (v1 == v2) {
         this.succCounter++;
@@ -216,7 +216,7 @@ var GasTap = (function () {
         tapOutput(false, error + ' - ' + msg)
       }
     }
-
+    
     function notEqual(v1, v2, msg) {
       if (v1 != v2) {
         this.succCounter++;
@@ -229,25 +229,25 @@ var GasTap = (function () {
     }
 
     function deepEqual(v1, v2, msg) {
-
+      
       var isDeepEqual = recursionDeepEqual(v1, v2)
-
+      
       function recursionDeepEqual(rv1, rv2) {
         if (!(rv1 instanceof Object) || !(rv2 instanceof Object)) return rv1 == rv2
-
+        
         if (Object.keys(rv1).length != Object.keys(rv2).length) return false
-
+      
         for (var k in rv1) {
           if (!(k in rv2)
-            || ((typeof rv1[k]) != (typeof rv2[k]))
+              || ((typeof rv1[k]) != (typeof rv2[k]))
           ) return false
-
+        
           if (!recursionDeepEqual(rv1[k], rv2[k])) return false
         }
-
+        
         return true
-      }
-
+      }        
+        
       if (isDeepEqual) {
         this.succCounter++;
         tapOutput(true, msg)
@@ -257,27 +257,27 @@ var GasTap = (function () {
         tapOutput(false, error + ' - ' + msg)
       }
     }
-
+    
     function notDeepEqual(v1, v2, msg) {
-
+      
       var isNotDeepEqual = recursionNotDeepEqual(v1, v2)
-
+      
       function recursionNotDeepEqual(rv1, rv2) {
         if (!(rv1 instanceof Object) || !(rv2 instanceof Object)) return rv1 != rv2
-
+        
         if (Object.keys(rv1).length != Object.keys(rv2).length) return true
-
+      
         for (var k in rv1) {
           if (!(k in rv2)
-            || ((typeof rv1[k]) != (typeof rv2[k]))
+              || ((typeof rv1[k]) != (typeof rv2[k]))
           ) return true
-
+        
           if (recursionNotDeepEqual(rv1[k], rv2[k])) return true
         }
-
+        
         return false
       }
-
+      
       if (isNotDeepEqual) {
         this.succCounter++;
         tapOutput(true, msg)
@@ -309,11 +309,11 @@ var GasTap = (function () {
         tapOutput(false, error + ' - ' + msg);
       }
     }
-
+    
     function throws(fn, msg) {
       try {
         fn()
-
+        
         this.failCounter++;
         tapOutput(false, 'exception wanted - ' + msg)
       } catch (e) {
@@ -321,11 +321,11 @@ var GasTap = (function () {
         tapOutput(true, msg)
       }
     }
-
+    
     function notThrow(fn, msg) {
       try {
         fn()
-
+        
         this.succCounter++;
         tapOutput(true, msg)
       } catch (e) {
@@ -333,19 +333,19 @@ var GasTap = (function () {
         tapOutput(false, 'unexpected exception:' + e.message + ' - ' + msg)
       }
     }
-
+    
     function skip(msg) {
       this.skipCounter++;
       tapOutput(true, msg + ' # SKIP')
       throw EXCEPTION_SKIP
     }
-
+    
     function pass(msg) {
       this.succCounter++;
       tapOutput(true, msg + ' # PASS')
       throw EXCEPTION_PASS
     }
-
+    
     function fail(msg) {
       this.failCounter++;
       tapOutput(false, msg + ' # FAIL')
@@ -353,8 +353,8 @@ var GasTap = (function () {
     }
   }
 
-
+  
   return GasTap
-
-
+  
+  
 }())

--- a/src/gas-tap-lib.js
+++ b/src/gas-tap-lib.js
@@ -56,8 +56,8 @@ var GasTap = (function () {
       , throws: throws
       , notThrow: notThrow
 
-      , isNaN: isNaN
-      , notIsNaN: notIsNaN
+      , nan: nan
+      , notNan: notNan
       
       , skip: skip
       , pass: pass
@@ -288,7 +288,7 @@ var GasTap = (function () {
       }
     }
 
-    function isNaN(v1, msg) {
+    function nan(v1, msg) {
       if (v1 !== v1) {
         this.succCounter++;
         tapOutput(true, msg)
@@ -299,7 +299,7 @@ var GasTap = (function () {
       }
     }
 
-    function notIsNaN(v1, msg) {
+    function notNan(v1, msg) {
       if (!(v1 !== v1)) {
         this.succCounter++;
         tapOutput(true, msg)

--- a/src/gast-tests.js
+++ b/src/gast-tests.js
@@ -16,62 +16,65 @@ function gastTestRunner() {
   * Github - https://github.com/zixia/gast
   *
   */
-  
-  
+
+
   //////////////////////////////////////////////////////////////////////////////////////////
   ///// GasT include header start
-  
-  if ((typeof GasTap)==='undefined') { // GasT Initialization. (only if not initialized yet.)
+
+  if ((typeof GasTap) === 'undefined') { // GasT Initialization. (only if not initialized yet.)
     eval(UrlFetchApp.fetch('https://raw.githubusercontent.com/zixia/gast/master/src/gas-tap-lib.js').getContentText())
   } // Class GasTap is ready for use now!
-  
+
   ///// GasT include header end
   //////////////////////////////////////////////////////////////////////////////////////////
-  
-  
+
+
   var test = new GasTap()
-  
+
 
   test('TAP ok', function (t) {
     t.ok(true, 'true is ok')
     t.notOk(false, 'false is not ok')
   })
-  
-  test('TAP equal', function (t) {    
+
+  test('TAP equal', function (t) {
     t.equal(true, true, 'true equal true')
     t.notEqual(true, false, 'true not equal false')
-    
+
     t.equal(99, String(99), 'number 99 equal string "99"')
-    
-    var a = { x: 3, y: { a: 4, b: 5}, z: [5, 6] }
-    var a2 = { x: 3, y: { a: 4, b: 5}, z: [5, 6] }
-    var b = { a: [3, 4], b: 3, c: {a: 3} }
-    
+
+    var a = { x: 3, y: { a: 4, b: 5 }, z: [5, 6] }
+    var a2 = { x: 3, y: { a: 4, b: 5 }, z: [5, 6] }
+    var b = { a: [3, 4], b: 3, c: { a: 3 } }
+
     t.deepEqual(a, a2, 'a deepEqual a2')
     t.notDeepEqual(a, b, 'a notDeepEqual b')
-    
+
     t.deepEqual([0], [0], '[0] deepEqual [0]')
     t.notDeepEqual([0], [0], 'this should fail: [0] notDeepEqual [0]')
+
+    t.isNaN(NaN, 'NaN is NaN');
+    t.notIsNaN({}, '{} not is NaN');
   })
-  
+
   test('TAP exception', function (t) {
     t.throws(function () { throw Error('exception') }, 'exception throwed')
     t.notThrow(function () { return }, 'no exception found')
   })
-  
+
   test('TAP setPrintDriver', function (t) {
     t.throws(function () { test.setPrintDriver('unknown') }, 'unknown driver throws exception')
   })
 
-  test('TAP skip', function (t) {  
+  test('TAP skip', function (t) {
     t.skip('skipped')
     t.fail('skip failed')
   })
-       
+
   test('TAP pass', function (t) {
     t.pass('passed')
   })
-  
+
   test('TAP fail', function (t) {
     t.fail('this should fail')
   })

--- a/src/gast-tests.js
+++ b/src/gast-tests.js
@@ -16,65 +16,66 @@ function gastTestRunner() {
   * Github - https://github.com/zixia/gast
   *
   */
-
-
+  
+  
   //////////////////////////////////////////////////////////////////////////////////////////
   ///// GasT include header start
-
-  if ((typeof GasTap) === 'undefined') { // GasT Initialization. (only if not initialized yet.)
+  
+  if ((typeof GasTap)==='undefined') { // GasT Initialization. (only if not initialized yet.)
     eval(UrlFetchApp.fetch('https://raw.githubusercontent.com/zixia/gast/master/src/gas-tap-lib.js').getContentText())
   } // Class GasTap is ready for use now!
-
+  
   ///// GasT include header end
   //////////////////////////////////////////////////////////////////////////////////////////
-
-
+  
+  
   var test = new GasTap()
-
+  
 
   test('TAP ok', function (t) {
     t.ok(true, 'true is ok')
     t.notOk(false, 'false is not ok')
   })
-
-  test('TAP equal', function (t) {
+  
+  test('TAP equal', function (t) {    
     t.equal(true, true, 'true equal true')
     t.notEqual(true, false, 'true not equal false')
-
+    
     t.equal(99, String(99), 'number 99 equal string "99"')
-
-    var a = { x: 3, y: { a: 4, b: 5 }, z: [5, 6] }
-    var a2 = { x: 3, y: { a: 4, b: 5 }, z: [5, 6] }
-    var b = { a: [3, 4], b: 3, c: { a: 3 } }
-
+    
+    var a = { x: 3, y: { a: 4, b: 5}, z: [5, 6] }
+    var a2 = { x: 3, y: { a: 4, b: 5}, z: [5, 6] }
+    var b = { a: [3, 4], b: 3, c: {a: 3} }
+    
     t.deepEqual(a, a2, 'a deepEqual a2')
     t.notDeepEqual(a, b, 'a notDeepEqual b')
-
+    
     t.deepEqual([0], [0], '[0] deepEqual [0]')
     t.notDeepEqual([0], [0], 'this should fail: [0] notDeepEqual [0]')
 
-    t.isNaN(NaN, 'NaN is NaN');
-    t.notIsNaN({}, '{} not is NaN');
-  })
+    t.isNaN(NaN, 'NaN is NaN')
+    t.notIsNaN({}, '{} not is NaN')
 
+  })
+  
   test('TAP exception', function (t) {
     t.throws(function () { throw Error('exception') }, 'exception throwed')
     t.notThrow(function () { return }, 'no exception found')
   })
-
+  
   test('TAP setPrintDriver', function (t) {
     t.throws(function () { test.setPrintDriver('unknown') }, 'unknown driver throws exception')
   })
 
-  test('TAP skip', function (t) {
+  test('TAP skip', function (t) {  
     t.skip('skipped')
     t.fail('skip failed')
   })
-
+       
   test('TAP pass', function (t) {
     t.pass('passed')
   })
-
+  
   test('TAP fail', function (t) {
     t.fail('this should fail')
   })

--- a/src/gast-tests.js
+++ b/src/gast-tests.js
@@ -53,8 +53,8 @@ function gastTestRunner() {
     t.deepEqual([0], [0], '[0] deepEqual [0]')
     t.notDeepEqual([0], [0], 'this should fail: [0] notDeepEqual [0]')
 
-    t.isNaN(NaN, 'NaN is NaN')
-    t.notIsNaN({}, '{} not is NaN')
+    t.nan(NaN, 'NaN is NaN')
+    t.notNan({}, '{} not is NaN')
 
   })
   


### PR DESCRIPTION
It seems `equal` methods doesn't compare `NaN`. The PR is adding a NaN test

```
t.isNaN(NaN, 'It\'s NaN');
t.notIsNaN({}, 'It\'s not NaN');
```