### PR TITLE
Fix some ReferenceErrors by adding var declarations

### DIFF
--- a/src/gas-tap-lib.js
+++ b/src/gas-tap-lib.js
@@ -116,9 +116,9 @@ var GasTap = (function () {
       } catch ( e /* if e instanceof String */) {
         //      Logger.log('caught exception: ' + e)
         
-        SKIP_RE = new RegExp(EXCEPTION_SKIP)
-        PASS_RE = new RegExp(EXCEPTION_PASS)
-        FAIL_RE = new RegExp(EXCEPTION_FAIL)
+        var SKIP_RE = new RegExp(EXCEPTION_SKIP)
+        var PASS_RE = new RegExp(EXCEPTION_PASS)
+        var FAIL_RE = new RegExp(EXCEPTION_FAIL)
         
         switch (true) {
           case SKIP_RE.test(e):


### PR DESCRIPTION
The error which was fixed: `ReferenceError: SKIP_RE is not defined (line 119, file «gast-tap-lib.gs»)`